### PR TITLE
Correct buttom left LED bug by fixing new upper hex check

### DIFF
--- a/MOUSE_DUAL/MOUSE_DUAL/src/sequencer_process.c
+++ b/MOUSE_DUAL/MOUSE_DUAL/src/sequencer_process.c
@@ -641,7 +641,6 @@ void processTouchLowerHex(uint8_t hexagon)
 	
 	manta_send_LED();
 	new_lower_hex = 0;
-	
 }
 
 void processTouchUpperHex(uint8_t hexagon)
@@ -716,9 +715,7 @@ void processTouchUpperHex(uint8_t hexagon)
 		
 		setKeyboardLEDsFor(currentSequencer, note);
 		
-		//set memory variables
-		new_upper_hex = 0;
-		prev_pitch = current_pitch;
+		
 	}
 	else
 	{
@@ -788,6 +785,10 @@ void processTouchUpperHex(uint8_t hexagon)
 	}
 	
 	manta_send_LED();
+	
+	//set memory variables
+	new_upper_hex = 0;
+	prev_pitch = current_pitch;
 }
 
 void processTouchFunctionButton(MantaButton button)
@@ -813,7 +814,7 @@ void processTouchFunctionButton(MantaButton button)
 		else
 		{
 			//Should not get here.
-	}	
+		}	
 		setSliderLEDsFor(currentSequencer, currentHexUI);
 	}
 	else if (button == ButtonTopRight)


### PR DESCRIPTION
@JoshuaStorm on here.

This resolves #22. Tough bugger.

@mulshine Can you give this a quick once-over to make sure that `new_upper_hex` wasn't supposed to be set to 0 conditionally? It seems to make most sense (and resolves the bug) to set this back to zero every time it gets handled, but I just wanted to make sure I am not removing something intentional. Thanks!